### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-breadgang.xyz


### PR DESCRIPTION
I assume the domain is no longer owned by the bread gang. This would allow to display the website using the github.io link